### PR TITLE
Fix: make the `dotnet serve` command be able to be restored and executed

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-serve": {
+      "version": "1.10.149",
+      "commands": [
+        "dotnet-serve"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
When the test target is a Blazor WebAssembly, not a Blazor Server, the test uses the `dotnet serve` tool to serve the static contents of the app published as an HTTP server. 

- See also: https://www.nuget.org/packages/dotnet-serve#readme-body-tab

To do that, the test invokes `dotnet restore` to restore the `dotnet serve` tool localy. But what tools should be restored is described in the `.config/dotnet-tools.json` file. 

- See also: https://learn.microsoft.com/dotnet/core/tools/global-tools#install-a-local-tool

The original source code didn't have the appropriate `.config/dotnet-tools.json` file. 

This pull request will add it, and then the test can be executed the local tool `dotnet serve` correctly.

