### PR TITLE
Improve: Add E2E test configuration files to be able to choose browser types and headless mode.

### DIFF
--- a/E2ETest/.settings/chromium-headless.runsettings
+++ b/E2ETest/.settings/chromium-headless.runsettings
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <TestRunParameters>
+    <Parameter name="Browser" value="chromium" />
+    <Parameter name="headless" value="true" />
+  </TestRunParameters>
+</RunSettings>

--- a/E2ETest/.settings/chromium.runsettings
+++ b/E2ETest/.settings/chromium.runsettings
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <TestRunParameters>
+    <Parameter name="Browser" value="chromium" />
+    <Parameter name="headless" value="false" />
+  </TestRunParameters>
+</RunSettings>

--- a/E2ETest/.settings/firefox-headless.runsettings
+++ b/E2ETest/.settings/firefox-headless.runsettings
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <TestRunParameters>
+    <Parameter name="Browser" value="firefox" />
+    <Parameter name="headless" value="true" />
+  </TestRunParameters>
+</RunSettings>

--- a/E2ETest/.settings/firefox.runsettings
+++ b/E2ETest/.settings/firefox.runsettings
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <TestRunParameters>
+    <Parameter name="Browser" value="firefox" />
+    <Parameter name="headless" value="false" />
+  </TestRunParameters>
+</RunSettings>

--- a/E2ETest/.settings/webkit-headless.runsettings
+++ b/E2ETest/.settings/webkit-headless.runsettings
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <TestRunParameters>
+    <Parameter name="Browser" value="webkit" />
+    <Parameter name="headless" value="true" />
+  </TestRunParameters>
+</RunSettings>

--- a/E2ETest/.settings/webkit.runsettings
+++ b/E2ETest/.settings/webkit.runsettings
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <TestRunParameters>
+    <Parameter name="Browser" value="webkit" />
+    <Parameter name="headless" value="false" />
+  </TestRunParameters>
+</RunSettings>


### PR DESCRIPTION
You can choose one of these `.runsettings` files from the "Test Explorer" of Visual Studio (see the attached screenshot) to specify which browser (Chromium, Firefox, WebKit) to use and run the browser with headless mode or not. In particular, running a browser without headless mode is convenient when developing an E2E test.

![image](https://github.com/fingers10/PlaywrightDemo/assets/95908/3f3220c5-15ab-44e7-b523-5148ed73e032)

